### PR TITLE
[PAYU-27] Expand order statuses to include 'pending' status

### DIFF
--- a/Cron/CheckTransactionState.php
+++ b/Cron/CheckTransactionState.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace PayU\EasyPlus\Cron;
 
 use Magento\Framework\Exception\LocalizedException;
@@ -189,18 +188,16 @@ class CheckTransactionState
      */
     public function getOrderCollection()
     {
-        // Not Needed for Cron
-        //$this->state->setAreaCode(\Magento\Framework\App\Area::AREA_FRONTEND); // or \Magento\Framework\App\Area::AREA_ADMINHTML, depending on your needs
-
         $collection = $this->_orderCollectionFactory->create()
             ->addFieldToSelect('*')
-            ->addFieldToFilter('status',
-                ['in' => ['pending_payment']]
-            )
-        ;
+            ->addFieldToFilter(
+                'status',
+                [
+                    'in' => explode(',', $this->getCRONConfigData('order_status'))
+                ]
+            );
 
         return $collection;
-
     }
 
 

--- a/Model/System/Config/Source/Order/Status/Pendingpayment.php
+++ b/Model/System/Config/Source/Order/Status/Pendingpayment.php
@@ -22,5 +22,5 @@ class Pendingpayment extends Status
     /**
      * @var string[]
      */
-    protected $_stateStatuses = [Order::STATE_PENDING_PAYMENT];
+    protected $_stateStatuses = [Order::STATE_NEW, Order::STATE_PENDING_PAYMENT];
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -15,6 +15,11 @@
                     <label>Disable</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="order_status" translate="label" type="multiselect" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>Order Status</label>
+                    <comment>The status of orders to be processed</comment>
+                    <source_model>PayU\EasyPlus\Model\System\Config\Source\Order\Status\Pendingpayment</source_model>
+                </field>
                 <field id="payumea_cron_delay" translate="label" type="text" sortOrder="120" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Delay (Minutes)</label>
                     <comment>


### PR DESCRIPTION
Eligible orders for processing by the cron now includes orders in pending status in addition to orders in pending_payment status.